### PR TITLE
ref: parse methods take stream as input

### DIFF
--- a/src/siotls/contents/alerts.py
+++ b/src/siotls/contents/alerts.py
@@ -58,9 +58,11 @@ class Alert(Exception, Content, Serializable):
             _alert_registry[cls.description] = cls
 
     @classmethod
-    def parse(abc, data):
-        stream = SerialIO(data)
-        level = AlertLevel(stream.read_int(1))
+    def parse(abc, stream):
+        try:
+            level = AlertLevel(stream.read_int(1))
+        except ValueError as exc:
+            raise IllegalParameter() from exc
         description = stream.read_int(1)
 
         try:
@@ -71,8 +73,6 @@ class Alert(Exception, Content, Serializable):
                 'description': description,
                 '_struct': '',
             })
-
-        stream.assert_eof()
 
         return cls('', level)
 

--- a/src/siotls/contents/application_data.py
+++ b/src/siotls/contents/application_data.py
@@ -16,8 +16,8 @@ class ApplicationData(Content, Serializable):
         self.content_data = data
 
     @classmethod
-    def parse(cls, data):
-        return cls(data)
+    def parse(cls, stream):
+        return cls(stream.read())
 
     def serialize(self):
         return self.data

--- a/src/siotls/contents/change_cipher_spec.py
+++ b/src/siotls/contents/change_cipher_spec.py
@@ -15,7 +15,8 @@ class ChangeCipherSpec(Content, Serializable):
         pass
 
     @classmethod
-    def parse(cls, data):
+    def parse(cls, stream):
+        data = stream.read_exactly(1)
         if data != b'\x01':
             msg = f"invalid {ContentType.CHANGE_CIPHER_SPEC} value: {data}"
             raise alerts.UnexpectedMessage(msg)

--- a/src/siotls/contents/heartbeat.py
+++ b/src/siotls/contents/heartbeat.py
@@ -32,8 +32,7 @@ class Heartbeat(Content, Serializable):
         self.padding = padding
 
     @classmethod
-    def parse(cls, data):
-        stream = SerialIO(data)
+    def parse(cls, stream):
         try:
             heartbeat_type = HeartbeatMessageType(stream.read_int(1))
         except ValueError as exc:

--- a/src/siotls/extensions/application_layer_protocol_negotiation.py
+++ b/src/siotls/extensions/application_layer_protocol_negotiation.py
@@ -1,6 +1,6 @@
 import textwrap
 from siotls.iana import ExtensionType, HandshakeType as HT
-from siotls.serial import SerializableBody, SerialIO
+from siotls.serial import SerializableBody
 from . import Extension
 
 
@@ -20,16 +20,8 @@ class ApplicationLayerProtocolNegotiation(Extension, SerializableBody):
         self.protocol_name_list = protocol_name_list
 
     @classmethod
-    def parse_body(cls, data):
-        stream = SerialIO(data)
-
-        protocol_name_list = []
-        list_length = stream.read_int(2)
-        while list_length > 0:
-            protocol_name_list.append(stream.read_var(1, limit=list_length))
-            list_length -= len(protocol_name_list[-1]) + 1
-
-        stream.assert_eof()
+    def parse_body(cls, stream):
+        protocol_name_list = stream.read_listvar(2, 1)
         return cls(protocol_name_list)
 
     def serialize_body(self):

--- a/src/siotls/extensions/certificate_authorities.py
+++ b/src/siotls/extensions/certificate_authorities.py
@@ -1,6 +1,6 @@
 import textwrap
 from siotls.iana import ExtensionType, HandshakeType as HT
-from siotls.serial import SerializableBody, SerialIO
+from siotls.serial import SerializableBody
 from . import Extension
 
 
@@ -21,19 +21,8 @@ class CertificateAuthorities(Extension, SerializableBody):
         self.autorities = autorities
 
     @classmethod
-    def parse_body(cls, data):
-        stream = SerialIO(data)
-
-        autorities = []
-        list_length = stream.read_int(2)
-        while list_length > 0:
-            autority = stream.read_var(2, limit=list_length)
-            list_length -= len(autority) + 2
-            autorities.append(autority)
-        if list_length < 0:
-            raise RuntimeError(f"buffer overflow while parsing {data}")
-
-        stream.assert_eof()
+    def parse_body(cls, stream):
+        autorities = stream.read_listvar(2, 2)
         return cls(autorities)
 
     def serialize(self):

--- a/src/siotls/extensions/cookie.py
+++ b/src/siotls/extensions/cookie.py
@@ -1,6 +1,6 @@
 import textwrap
 from siotls.iana import ExtensionType, HandshakeType as HT
-from siotls.serial import SerializableBody, SerialIO
+from siotls.serial import SerializableBody
 from . import Extension
 
 
@@ -19,10 +19,8 @@ class Cookie(Extension, SerializableBody):
         self.cookie = cookie
 
     @classmethod
-    def parse_body(cls, data):
-        stream = SerialIO(data)
+    def parse_body(cls, stream):
         cookie = stream.read_var(2)
-        stream.assert_eof()
         return cls(cookie)
 
     def serialize_body(self):

--- a/src/siotls/extensions/early_data.py
+++ b/src/siotls/extensions/early_data.py
@@ -1,6 +1,6 @@
 import textwrap
 from siotls.iana import ExtensionType, HandshakeType as HT
-from siotls.serial import SerializableBody, SerialIO
+from siotls.serial import SerializableBody
 from . import Extension
 
 
@@ -8,15 +8,15 @@ class EarlyData(Extension, SerializableBody):
     extension_type = ExtensionType.EARLY_DATA
     _handshake_types = {HT.CLIENT_HELLO, HT.ENCRYPTED_EXTENSIONS}
 
-    _struct = ''
+    # The mere presence of the extension is enough
+    _struct = ""
 
     def __init__(self):
         pass
 
     @classmethod
-    def parse_body(cls, data):
-        SerialIO(data).ensure_eof()
-        return cls
+    def parse_body(cls, stream):
+        return cls()
 
     def serialize_body(self):
         return b''
@@ -37,10 +37,8 @@ class NewSessionEarlyData(Extension, SerializableBody):
         self.max_early_data_size = max_early_data_size
 
     @classmethod
-    def parse_body(cls, data):
-        stream = SerialIO(data)
+    def parse_body(cls, stream):
         max_early_data_size = stream.read_int(4)
-        stream.ensure_eof()
         return cls(max_early_data_size)
 
     def serialize_body(self):

--- a/src/siotls/extensions/heartbeat.py
+++ b/src/siotls/extensions/heartbeat.py
@@ -1,6 +1,6 @@
 import textwrap
 from siotls.iana import ExtensionType, HandshakeType as HT, HeartbeatMode
-from siotls.serial import SerializableBody, SerialIO
+from siotls.serial import SerializableBody, SerializationError
 from . import Extension
 from ..contents import alerts
 
@@ -20,14 +20,13 @@ class Heartbeat(Extension, SerializableBody):
         self.mode = mode
 
     @classmethod
-    def parse_body(cls, data):
-        stream = SerialIO(data)
+    def parse_body(cls, stream):
         try:
             mode = HeartbeatMode(stream.read_int(1))
+        except SerializationError:
+            raise
         except ValueError as exc:
             raise alerts.IllegalParameter() from exc
-        stream.assert_eof()
-
         return cls(mode)
 
     def serialize_body(self):

--- a/src/siotls/extensions/max_fragment_length.py
+++ b/src/siotls/extensions/max_fragment_length.py
@@ -1,6 +1,6 @@
 import textwrap
 from siotls.iana import ExtensionType, HandshakeType as HT, MaxFragmentLength
-from siotls.serial import SerializableBody
+from siotls.serial import SerializableBody, SerializationError
 from . import Extension
 from ..contents import alerts
 
@@ -20,12 +20,11 @@ class MaxFragmentLength(Extension, SerializableBody):
         self.max_fragment_length = max_fragment_length
 
     @classmethod
-    def parse_body(cls, data):
-        if len(data) != 1:
-            raise ValueError(f"Expected exactly 1 byte but found {len(data)}")
-        max_fragment_length = int.from_bytes(data[0], 'big')
+    def parse_body(cls, stream):
         try:
-            max_fragment_length = MaxFragmentLength(max_fragment_length)
+            max_fragment_length = MaxFragmentLength(stream.read_int(1))
+        except SerializationError:
+            raise
         except ValueError as exc:
             raise alerts.IllegalParameter() from exc
         return cls(max_fragment_length)

--- a/src/siotls/extensions/oid_filters.py
+++ b/src/siotls/extensions/oid_filters.py
@@ -30,21 +30,13 @@ class OIDFilters(Extension, SerializableBody):
         self.filters = filters
 
     @classmethod
-    def parse_body(cls, data):
-        stream = SerialIO(data)
-
+    def parse_body(cls, stream):
         filters = []
-        list_length = stream.read_int(2)
-        while list_length > 0:
-            cert_ext_oid = stream.read_var(1)
-            list_length -= len(cert_ext_oid) - 1
-            cert_ext_values = stream.read_var(2)
-            list_length -= len(cert_ext_values) - 2
+        list_stream = SerialIO(stream.read_var(2))
+        while not list_stream.is_eof():
+            cert_ext_oid = list_stream.read_var(1)
+            cert_ext_values = list_stream.read_var(2)
             filters.append(OIDFilter(cert_ext_oid, cert_ext_values))
-        if list_length < 0:
-            raise RuntimeError(f"buffer overflow while parsing {data}")
-
-        stream.assert_eof()
         return cls(filters)
 
     def serialize_body(self):

--- a/src/siotls/extensions/padding.py
+++ b/src/siotls/extensions/padding.py
@@ -13,14 +13,14 @@ class Padding(Extension, SerializableBody):
             opaque zeros[Extension.extension_length];
         } PaddingExtension;
     """).strip()
-    zeros: bytes
+    zeros_count: int
 
-    def __init__(self, zeros):
-        self.zeros = zeros
+    def __init__(self, zeros_count):
+        self.zeros_count = zeros_count
 
     @classmethod
-    def parse_body(cls, data):
-        return cls(data)
+    def parse_body(cls, stream):
+        return cls(len(stream.read()))
 
     def serialize_body(self):
-        return self.zeros
+        return b'\x00' * self.zeros_count

--- a/src/siotls/extensions/post_handshake_auth.py
+++ b/src/siotls/extensions/post_handshake_auth.py
@@ -1,5 +1,5 @@
 from siotls.iana import ExtensionType, HandshakeType as HT
-from siotls.serial import SerializableBody, TooMuchData
+from siotls.serial import SerializableBody
 from . import Extension
 
 
@@ -7,16 +7,14 @@ class PostHandshakeAuth(Extension, SerializableBody):
     extension_type = ExtensionType.POST_HANDSHAKE_AUTH
     _handshake_types = {HT.CLIENT_HELLO}
 
-    _struct = ''
+    # The mere presence of the extension is enough
+    _struct = ""
 
     def __init__(self):
         pass
 
     @classmethod
-    def parse_body(cls, data):
-        if data:
-            msg = f"Expected end of stream but {len(data)} bytes remain."
-            raise TooMuchData(msg)
+    def parse_body(cls, stream):
         return cls()
 
     def serialize_body(self):

--- a/src/siotls/extensions/psk_key_exchange_modes.py
+++ b/src/siotls/extensions/psk_key_exchange_modes.py
@@ -1,6 +1,6 @@
 import textwrap
 from siotls.iana import ExtensionType, HandshakeType as HT, PskKeyExchangeMode
-from siotls.serial import SerializableBody, SerialIO
+from siotls.serial import SerializableBody
 from siotls.utils import try_cast
 from . import Extension
 
@@ -20,13 +20,11 @@ class PskKeyExchangeModes(Extension, SerializableBody):
         self.zeros = zeros
 
     @classmethod
-    def parse_body(cls, data):
-        stream = SerialIO(data)
+    def parse_body(cls, stream):
         ke_modes = [
             try_cast(PskKeyExchangeMode, ke_mode)
-            for ke_mode in stream.read_var(1)
+            for ke_mode in stream.read_listint(1, 1)
         ]
-        stream.assert_eof()
         return cls(ke_modes)
 
     def serialize_body(self):

--- a/src/siotls/extensions/signed_certificate_timestamp.py
+++ b/src/siotls/extensions/signed_certificate_timestamp.py
@@ -1,5 +1,5 @@
 from siotls.iana import ExtensionType, HandshakeType as HT
-from siotls.serial import SerializableBody, TooMuchData
+from siotls.serial import SerializableBody
 from . import Extension
 
 
@@ -14,10 +14,7 @@ class SignedCertificateTimestamp(Extension, SerializableBody):
         pass
 
     @classmethod
-    def parse_body(cls, data):
-        if data:
-            msg = f"Expected end of stream but {len(data)} bytes remain."
-            raise TooMuchData(msg)
+    def parse_body(cls, stream):
         return cls()
 
     def serialize(self):

--- a/src/siotls/extensions/use_srtp.py
+++ b/src/siotls/extensions/use_srtp.py
@@ -1,7 +1,7 @@
 import itertools
 import textwrap
 from siotls.iana import ExtensionType, HandshakeType as HT
-from siotls.serial import SerializableBody, SerialIO
+from siotls.serial import SerializableBody
 from . import Extension
 
 
@@ -27,14 +27,12 @@ class UseSRTP(Extension, SerializableBody):
         self.mki = mki
 
     @classmethod
-    def parse_body(cls, data):
-        stream = SerialIO(data)
-
+    def parse_body(cls, stream):
+        # cannot use read_listint as the type in uint8[2], not uint16
         it = iter(stream.read_var(2))
         protection_profiles = list(zip(it, it))
         mki = stream.read_var(1)
 
-        stream.assert_eof()
         return cls(protection_profiles, mki)
 
     def serialize(self):


### PR DESCRIPTION
[Big Rewrite] of the many `parse` and `parse_body` methods.

Take a stream as input instead of raw data, to avoid the many `data` and `SerialIO` conversions.

Use new approaches to parsing lists, to avoid having to manually manipulate the list length, and to take advantage of the `read_listvar` and `read_listvar` (renammed from `read_varint`) methods.

The other goal of this rewrite is to make the many parsers more consistent with one another, to review them and to fix bugs along the way.

[Big Rewrite]: https://youtu.be/xCGu5Z_vaps